### PR TITLE
[Housekeeping,Bug] Fix bug in NetworkBoundaryDTO and Add refactor in MetabolicNetworkXMLLoader

### DIFF
--- a/src/main/java/metapenta/commands/NetworkBoundary.java
+++ b/src/main/java/metapenta/commands/NetworkBoundary.java
@@ -6,7 +6,7 @@ import metapenta.tools.io.writers.NetworkBoundaryWriter;
 
 /**
  * args[0]: First metabolic network in XML format
- * args[1]: Second metabolic network in XML format
+ * args[1]: Output file path
  */
 public class NetworkBoundary {
     public static void main(String[] args) throws Exception {

--- a/src/main/java/metapenta/model/dto/NetworkBoundaryDTO.java
+++ b/src/main/java/metapenta/model/dto/NetworkBoundaryDTO.java
@@ -18,7 +18,7 @@ public class NetworkBoundaryDTO {
         return sinks;
     }
 
-    public void setSources(List<Metabolite> sources) {
-        this.sources = sources;
+    public List<Metabolite> getSources() {
+        return sources;
     }
 }

--- a/src/main/java/metapenta/model/networks/MetabolicNetwork.java
+++ b/src/main/java/metapenta/model/networks/MetabolicNetwork.java
@@ -10,7 +10,6 @@ import metapenta.model.petrinet.Place;
 import metapenta.model.petrinet.Transition;
 
 import java.util.*;
-import java.util.Map.Entry;
 
 public class MetabolicNetwork {
     private MetabolicNetworkElements metabolicNetworkElements;
@@ -126,8 +125,10 @@ public class MetabolicNetwork {
     public List<Place<Metabolite>> getSinks() {
         List<Place<Metabolite>> sinkPlaces = new ArrayList<>();
         List<String> placesIDs = petriNetElements.getPlacesIDs();
+
         for(String placeID: placesIDs) {
             Place<Metabolite> place = petriNetElements.getPlace(placeID);
+
             if (place.isSink()){
                 sinkPlaces.add(place);
             }
@@ -189,7 +190,7 @@ public class MetabolicNetwork {
     }
     public void addReaction(Reaction reaction){
         metabolicNetworkElements.addReaction(reaction);
-        petriNetElements.loadReactionToPetriNet(reaction);
+        petriNetElements.loadReactionToPetriNetwork(reaction);
     }
     public List<Reaction> getReactionsUnbalanced(){
         return metabolicNetworkElements.getReactionsUnbalanced();

--- a/src/main/java/metapenta/model/networks/PetriNetElements.java
+++ b/src/main/java/metapenta/model/networks/PetriNetElements.java
@@ -46,7 +46,7 @@ public class PetriNetElements {
     }
 
 
-    public void loadReactionToPetriNet(Reaction reaction) {
+    public void loadReactionToPetriNetwork(Reaction reaction) {
         Transition transition = this.createAndLoadTransitionToPetriNet(reaction);
 
         List<Edge> edgesIn = this.loadMetabolitesAndCreateEdgeList(reaction.getReactants());
@@ -56,8 +56,8 @@ public class PetriNetElements {
         List<Edge> edgesOut = this.loadMetabolitesAndCreateEdgeList(reaction.getProducts());
         transition.AddEdgesOut(edgesOut);
 
-        loadOutEdgesInPlacesOfTransition(transition);
-        loadInEdgesInPlacesOfTransition(transition);
+        loadOutEdgesInReactantPlaces(transition);
+        loadInEdgesInProductPlaces(transition);
     }
 
     private List<Edge> loadMetabolitesAndCreateEdgeList(List<ReactionComponent> reactionComponents){
@@ -94,7 +94,7 @@ public class PetriNetElements {
         return transition;
     }
 
-    private void loadOutEdgesInPlacesOfTransition(Transition transition) {
+    private void loadOutEdgesInReactantPlaces(Transition transition) {
         List<Edge<Place>> edges = transition.getEdgesIn();
         for (Edge<Place> edge: edges) {
             Place place = edge.getTarget();
@@ -104,7 +104,7 @@ public class PetriNetElements {
         }
     }
 
-    private void loadInEdgesInPlacesOfTransition(Transition transition) {
+    private void loadInEdgesInProductPlaces(Transition transition) {
         List<Edge<Place>> edges = transition.getEdgesOut();
         for (Edge<Place> edge: edges) {
             Place place = edge.getTarget();

--- a/src/main/java/metapenta/services/MetabolicNetworkService.java
+++ b/src/main/java/metapenta/services/MetabolicNetworkService.java
@@ -16,14 +16,17 @@ import java.util.Map;
 
 public class MetabolicNetworkService implements IMetabolicNetworkService {
     private final MetabolicNetwork metabolicNetwork;
+
     public MetabolicNetworkService(String networkFile) throws Exception{
         MetabolicNetworkXMLLoader networkLoader = new MetabolicNetworkXMLLoader();
         metabolicNetwork = networkLoader.loadNetwork(networkFile);
     }
+
     public MetabolicNetworkService(InputStream is) throws Exception{
         MetabolicNetworkXMLLoader networkLoader = new MetabolicNetworkXMLLoader();
         metabolicNetwork = networkLoader.loadNetwork(is);
     }
+
     public ConnectedComponentsDTO connectedComponents() {
         ConnectedComponentsService connectedComponentsService = new ConnectedComponentsService(this.metabolicNetwork);
 

--- a/src/main/java/metapenta/tools/io/loaders/MetabolicNetworkXMLLoader.java
+++ b/src/main/java/metapenta/tools/io/loaders/MetabolicNetworkXMLLoader.java
@@ -21,72 +21,66 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
-/**
- * Loads a metabolic network froman XML file
- * @author Jorge Duitama
- */
+
 public class MetabolicNetworkXMLLoader {
 	private int metaboliteNumber = 0;
 	private int reactionNumber = 0;
 
 	public MetabolicNetwork loadNetwork(String filename) throws Exception {
-		InputStream is = new FileInputStream(filename);
+		InputStream inputStream = new FileInputStream(filename);
 
-		return loadNetwork(is);
+		return loadNetwork(inputStream);
 	}
 
-	public MetabolicNetwork loadNetwork (InputStream is) throws Exception {
-		MetabolicNetwork mn = null;
+	public MetabolicNetwork loadNetwork (InputStream inputStream) throws Exception {
+		MetabolicNetwork metabolicNetwork = null;
 
 		DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-		Document doc = documentBuilder.parse(new InputSource(is));
+		Document doc = documentBuilder.parse(new InputSource(inputStream));
 
 		Element rootElement = doc.getDocumentElement();
 		NodeList offspring = rootElement.getChildNodes(); 
 
 		for(int i=0;i<offspring.getLength();i++){  
 			Node node = offspring.item(i);
-			if (node instanceof Element){ 
-				Element elem = (Element)node;
-				if(XMLAttributes.ELEMENT_MODEL.equals(elem.getNodeName())) {
-					mn = loadModel(elem);
+			if (node instanceof Element){
+				Element element = (Element)node;
+
+				if(XMLAttributes.ELEMENT_MODEL.equals(element.getNodeName())) {
+					metabolicNetwork = loadModel(element);
 				}
 			}
 		}
-		if(mn != null) {
-			return mn;
+
+		if(metabolicNetwork != null) {
+			return metabolicNetwork;
 		}
 
-		is.close();
+		inputStream.close();
 
 		throw new IOException("Malformed XML file. The element "+XMLAttributes.ELEMENT_MODEL+" could not be found");
 	}
 	
-	private MetabolicNetwork loadModel(Element modelElem) throws Exception {
-		MetabolicNetwork answer = new MetabolicNetwork();
+	private MetabolicNetwork loadModel(Element modelElement) throws Exception {
+		MetabolicNetwork metabolicNetwork = new MetabolicNetwork();
 		
-		Element compartments = getElementByID(modelElem, XMLAttributes.ELEMENT_LISTCOMPARTMENTS);
-		loadCompartments (compartments, answer);
+		Element compartments = getElementByID(modelElement, XMLAttributes.ELEMENT_LISTCOMPARTMENTS);
+		loadCompartments(compartments, metabolicNetwork);
 		
-		Element products = getElementByID(modelElem, XMLAttributes.ELEMENT_FBC_LISTGENEPRODUCTS);
-		loadGeneProducts (products, answer);
+		Element products = getElementByID(modelElement, XMLAttributes.ELEMENT_FBC_LISTGENEPRODUCTS);
+		loadGeneProducts(products, metabolicNetwork);
 		
-		Element metabolites = getElementByID(modelElem, XMLAttributes.ELEMENT_LISTMETABOLITES);
-		loadMetabolites (metabolites, answer);
+		Element metabolites = getElementByID(modelElement, XMLAttributes.ELEMENT_LISTMETABOLITES);
+		loadMetabolites(metabolites, metabolicNetwork);
 		
-		Element parameters = getElementByID(modelElem, XMLAttributes.ELEMENT_LISTPARAMETERS);
-		loadParameters (parameters, answer);
+		Element parameters = getElementByID(modelElement, XMLAttributes.ELEMENT_LISTPARAMETERS);
+		loadParameters(parameters, metabolicNetwork);
 		
-		Element reactions = getElementByID(modelElem, XMLAttributes.ELEMENT_LISTREACTIONS);
-		loadReactions (reactions, answer);
+		Element reactions = getElementByID(modelElement, XMLAttributes.ELEMENT_LISTREACTIONS);
+		loadReactions(reactions, metabolicNetwork);
 		
-		return answer;
+		return metabolicNetwork;
 	}
-	
-	
-	
-
-	
 
 	private Element getElementByID(Element modelElem, String nodeName) {
 		NodeList offspring = modelElem.getChildNodes(); 
@@ -120,6 +114,7 @@ public class MetabolicNetworkXMLLoader {
 			}
 		}	
 	}
+
 	private void loadParameters(Element listElem, MetabolicNetwork network) throws IOException {
 		NodeList offspring = listElem.getChildNodes(); 
 		for(int i=0;i<offspring.getLength();i++){  
@@ -137,8 +132,7 @@ public class MetabolicNetworkXMLLoader {
 		}
 		
 	}
-	
-	
+
 	private void loadGeneProducts(Element listElem, MetabolicNetwork network) throws IOException {
 		NodeList offspring = listElem.getChildNodes(); 
 		for(int i=0;i<offspring.getLength();i++){  
@@ -205,72 +199,89 @@ public class MetabolicNetworkXMLLoader {
 		
 	}
 
-	private void loadReactions(Element listElem, MetabolicNetwork network) throws Exception {
-		NodeList offspring = listElem.getChildNodes();
-		for(int i=0;i<offspring.getLength();i++){  
-			Node node = offspring.item(i);			
-			if (node instanceof Element){				
-				Element elem = (Element)node;
-				if(XMLAttributes.ELEMENT_REACTION.equals(elem.getNodeName())) {
-					String id = elem.getAttribute(XMLAttributes.ATTRIBUTE_ID);
-					if(id==null || id.length()==0) throw new IOException("Every reaction should have an id");
-					String name = elem.getAttribute(XMLAttributes.ATTRIBUTE_NAME);
+	private void loadReactions(Element reactions, MetabolicNetwork network) throws Exception {
+		NodeList offspring = reactions.getChildNodes();
 
-					if(name==null || name.length()==0) throw new IOException("Invalid name for reaction with id "+id);
-					String reversibleStr = elem.getAttribute(XMLAttributes.ATTRIBUTE_REVERSIBLE);
-					List<GeneProduct> enzymes = new ArrayList<GeneProduct>();
-					List<ReactionComponent> reactants = new ArrayList<ReactionComponent>();
-					List<ReactionComponent> products = new ArrayList<ReactionComponent>();
-					String lbCode = elem.getAttribute(XMLAttributes.ATTRIBUTE_FBC_LOWERBOUND);
-					String ubCode = elem.getAttribute(XMLAttributes.ATTRIBUTE_FBC_UPPERBOUND);
-					
-					NodeList offspring2 = elem.getChildNodes(); 
-					for(int j=0;j<offspring2.getLength();j++) {
-						Node node2 = offspring2.item(j);
-						if (node2 instanceof Element){ 
-							Element elem2 = (Element) node2;
-							//TODO: Load annotations
-							if(XMLAttributes.ELEMENT_FBC_GENEASSOC.equals(elem2.getNodeName())) {
-								enzymes = loadEnzymes(id, elem2, network);
-							}
-							if(XMLAttributes.ELEMENT_LISTREACTANTS.equals(elem2.getNodeName())) {
-								reactants = loadReactionComponents(id, elem2, network);
-							}
-							if(XMLAttributes.ELEMENT_LISTMETABPRODUCTS.equals(elem2.getNodeName())) {
-								products = loadReactionComponents(id, elem2, network);
-							}
-						}
-					}
-					if(reactants.isEmpty()) {
-						System.err.println("WARN. No reactants found for reaction "+id);
-						//continue;
-					}
-					if(products.size()==0) {						
-						System.err.println("WARN. No products found for reaction "+id);
-						//continue;
-					}
-					
-					Reaction r = new Reaction(id, name, reactants, products, reactionNumber);
+		for(int i=0;i<offspring.getLength();i++){
+			Node node = offspring.item(i);
+
+			if (node instanceof Element){
+				Element reactionElement = (Element)node;
+
+				if(XMLAttributes.ELEMENT_REACTION.equals(reactionElement.getNodeName())) {
+					String id = reactionElement.getAttribute(XMLAttributes.ATTRIBUTE_ID);
+					if(id==null || id.length()==0) throw new IOException("Every reactionElement must have an id");
+
+					String name = reactionElement.getAttribute(XMLAttributes.ATTRIBUTE_NAME);
+					if(name==null || name.length()==0) throw new IOException("Invalid name for reactionElement with id "+id);
+
+					String reversible = reactionElement.getAttribute(XMLAttributes.ATTRIBUTE_REVERSIBLE);
+					String lowerBound = reactionElement.getAttribute(XMLAttributes.ATTRIBUTE_FBC_LOWERBOUND);
+					String upperBound = reactionElement.getAttribute(XMLAttributes.ATTRIBUTE_FBC_UPPERBOUND);
+
 					this.reactionNumber++;
-					if("true".equals(reversibleStr)) r.setReversible(true);
-					r.setEnzymes(enzymes);
-					if(lbCode!=null && lbCode.trim().length()>0) {
-						String valueS = network.getValueParameter(lbCode);
-						if(valueS ==null) throw new IOException("Lower bound parameter id not found for reaction: "+r.getId());
-						r.setLowerBoundFluxParameterId(lbCode);
-						r.setLowerBoundFlux(Double.parseDouble(valueS));
-					}
-					if(ubCode!=null && ubCode.trim().length()>0) {
-						String valueS = network.getValueParameter(ubCode);
-						if(valueS ==null) throw new IOException("Upper bound parameter id not found for reaction: "+r.getId());
-						r.setUpperBoundFluxParameterId(ubCode);
-						r.setUpperBoundFlux(Double.parseDouble(valueS));					
-					}
-					network.addReaction(r);
+					Reaction reaction = loadReaction(reactionElement, network, id, name);
+
+					reaction.setReversible(reversible.equals(("true")));
+					setBoundsInReaction(reaction, lowerBound, upperBound, network);
+
+					network.addReaction(reaction);
 				}
 			}
 		}
-		
+	}
+
+	private Reaction loadReaction (Element reactionElement, MetabolicNetwork network, String id, String name) throws Exception {
+		List<GeneProduct> enzymes = new ArrayList<GeneProduct>();
+		List<ReactionComponent> reactants = new ArrayList<ReactionComponent>();
+		List<ReactionComponent> products = new ArrayList<ReactionComponent>();
+
+		NodeList offspring = reactionElement.getChildNodes();
+
+		for(int j=0; j<offspring.getLength(); j++) {
+			Node node = offspring.item(j);
+			if (node instanceof Element){
+				Element element = (Element) node;
+
+				if(XMLAttributes.ELEMENT_FBC_GENEASSOC.equals(element.getNodeName())) {
+					enzymes = loadEnzymes(id, element, network);
+				}
+				if(XMLAttributes.ELEMENT_LISTREACTANTS.equals(element.getNodeName())) {
+					reactants = loadReactionComponents(id, element, network);
+				}
+				if(XMLAttributes.ELEMENT_LISTMETABPRODUCTS.equals(element.getNodeName())) {
+					products = loadReactionComponents(id, element, network);
+				}
+			}
+		}
+
+		if(reactants.isEmpty()) {
+			System.err.println("WARN. No reactants found for reactionElement " + id);
+		}
+		if(products.isEmpty()) {
+			System.err.println("WARN. No products found for reactionElement " + id);
+		}
+
+		Reaction reaction = new Reaction(id, name, reactants, products, reactionNumber);
+		reaction.setEnzymes(enzymes);
+
+		return reaction;
+	}
+
+	private void setBoundsInReaction(Reaction reaction, String lowerBound, String upperBound, MetabolicNetwork network) throws Exception {
+		if(lowerBound!=null && !lowerBound.trim().isEmpty()) {
+			String lowerBoundValue = network.getValueParameter(lowerBound);
+			if(lowerBoundValue ==null) throw new IOException("Lower bound parameter id not found for reactionElement: "+reaction.getId());
+			reaction.setLowerBoundFluxParameterId(lowerBound);
+			reaction.setLowerBoundFlux(Double.parseDouble(lowerBoundValue));
+		}
+
+		if(upperBound!=null && !upperBound.trim().isEmpty()) {
+			String valueS = network.getValueParameter(upperBound);
+			if(valueS ==null) throw new IOException("Upper bound parameter id not found for reactionElement: "+reaction.getId());
+			reaction.setUpperBoundFluxParameterId(upperBound);
+			reaction.setUpperBoundFlux(Double.parseDouble(valueS));
+		}
 	}
 
 	private List<GeneProduct> loadEnzymes(String reactionId, Element listElem, MetabolicNetwork network) throws Exception {

--- a/src/main/java/metapenta/tools/io/writers/NetworkBoundaryWriter.java
+++ b/src/main/java/metapenta/tools/io/writers/NetworkBoundaryWriter.java
@@ -16,10 +16,11 @@ public class NetworkBoundaryWriter implements Writer {
     private static final String SOURCES_JSON_KEY = "Sources";
     private NetworkBoundaryDTO networkBoundaryDTO;
 
-    private String outPath;
-    public NetworkBoundaryWriter(NetworkBoundaryDTO networkBoundaryDTO, String outPath){
+    private String outputFile;
+
+    public NetworkBoundaryWriter(NetworkBoundaryDTO networkBoundaryDTO, String outputFile){
         this.networkBoundaryDTO = networkBoundaryDTO;
-        this.outPath = outPath;
+        this.outputFile = outputFile;
     }
 
     private JSONObject getJsonBoundaryObject() {
@@ -41,7 +42,7 @@ public class NetworkBoundaryWriter implements Writer {
 
     private JSONArray getSourcesJsonArray() {
         JSONArray metabolites = new JSONArray();
-        for(Metabolite metabolite: networkBoundaryDTO.getSinks()){
+        for(Metabolite metabolite: networkBoundaryDTO.getSources()){
             metabolites.add(metabolite);
         }
 
@@ -51,6 +52,6 @@ public class NetworkBoundaryWriter implements Writer {
     public void write() throws IOException {
         JSONObject jsonObject = getJsonBoundaryObject();
 
-        Files.write(Paths.get(outPath), jsonObject.toJSONString().getBytes());
+        Files.write(Paths.get(outputFile), jsonObject.toJSONString().getBytes());
     }
 }


### PR DESCRIPTION
## Context

While testing #14 using [e coli core model](http://bigg.ucsd.edu/models/e_coli_core) I noticed that there was something odd with our sink and source metabolites. Taking a closer look  to the output given by [findRootNPmets](https://opencobra.github.io/cobratoolbox/stable/modules/analysis/exploration/index.html?highlight=findRootNPmets#src.analysis.exploration.findRootNPmets) there were some metabolites that we weren't considering as sources, for instance `M_gln__L_e`. At first I thought it was an error while loading the network from a SBML but then I realized it was actually a bug.

## Description
This PR fixes a bug in `src/main/java/metapenta/tools/io/writers/NetworkBoundaryWriter.java` which was returning sinks instead of sources. Additionally, following the boy scout rule, it refactors several methods involved in the bug or my prior inspection in metabolic network loader. 

> **_NOTE:_**  I believe refactoring while solving or adding features is a great way of improving MetaPenta :).

## Test
I ran `NetworkBoundary` command and this was the result (you can use [JsonFormatter](https://jsonformatter.org/)): 

```
{"Sinks":[{"id": "M_13dpg_c", "name":"3-Phospho-D-glyceroyl phosphate"},{"id": "M_actp_c", "name":"Acetyl phosphate"},{"id": "M_for_c", "name":"Formate"},{"id": "M_succoa_c", "name":"Succinyl-CoA"}],"Sources":[{"id": "M_2pg_c", "name":"D-Glycerate 2-phosphate"},{"id": "M_ac_e", "name":"Acetate"},{"id": "M_acald_e", "name":"Acetaldehyde"},{"id": "M_akg_e", "name":"2-Oxoglutarate"},{"id": "M_co2_e", "name":"CO2 CO2"},{"id": "M_etoh_e", "name":"Ethanol"},{"id": "M_for_e", "name":"Formate"},{"id": "M_fru_e", "name":"D-Fructose"},{"id": "M_fum_e", "name":"Fumarate"},{"id": "M_glc__D_e", "name":"D-Glucose"},{"id": "M_gln__L_e", "name":"L-Glutamine"},{"id": "M_glu__L_e", "name":"L-Glutamate"},{"id": "M_h2o_e", "name":"H2O H2O"},{"id": "M_lac__D_e", "name":"D-Lactate"},{"id": "M_mal__L_e", "name":"L-Malate"},{"id": "M_nh4_e", "name":"Ammonium"},{"id": "M_o2_e", "name":"O2 O2"},{"id": "M_pi_e", "name":"Phosphate"},{"id": "M_pyr_e", "name":"Pyruvate"},{"id": "M_r5p_c", "name":"Alpha-D-Ribose 5-phosphate"}]}
```
I manually inspected some of the metabolites and they were correct according to our definition of source and sink.

