### PR TITLE
[BOUNDARY] Fix metabolic network boundary finder

### DIFF
--- a/src/main/java/metapenta/model/dto/NetworkBoundaryDTO.java
+++ b/src/main/java/metapenta/model/dto/NetworkBoundaryDTO.java
@@ -1,24 +1,17 @@
 package metapenta.model.dto;
 
-import metapenta.model.metabolic.network.Metabolite;
+import metapenta.model.metabolic.network.Reaction;
 
 import java.util.List;
 
 public class NetworkBoundaryDTO {
+    private List<Reaction> exchangeReactions;
 
-    private List<Metabolite> sinks;
-
-    private List<Metabolite> sources;
-    public NetworkBoundaryDTO(List<Metabolite> sinks, List<Metabolite> sources){
-        this.sinks = sinks;
-        this.sources = sources;
+    public NetworkBoundaryDTO(List<Reaction> exchangeReactions){
+        this.exchangeReactions = exchangeReactions;
     }
 
-    public List<Metabolite> getSinks() {
-        return sinks;
-    }
-
-    public List<Metabolite> getSources() {
-        return sources;
+    public List<Reaction> getExchangeReactions() {
+        return exchangeReactions;
     }
 }

--- a/src/main/java/metapenta/model/networks/MetabolicNetwork.java
+++ b/src/main/java/metapenta/model/networks/MetabolicNetwork.java
@@ -28,6 +28,7 @@ public class MetabolicNetwork {
     public void addCompartment(Compartment compartment) {
 		metabolicNetworkElements.addCompartment(compartment);
 	}
+
     public List<Compartment> getCompartmentsAsList() {
 		return metabolicNetworkElements.getCompartmentsAsList();
 	}
@@ -39,9 +40,11 @@ public class MetabolicNetwork {
     public void addParameter(String id, String value) {
 		metabolicNetworkElements.addParameter(id, value);
 	}
+
     public String getValueParameter(String parameterId) {
     	return metabolicNetworkElements.getValueParameter(parameterId);
     }
+
     public Map<String, String> getParameters() {
 		return metabolicNetworkElements.getParameters();
 	}
@@ -49,6 +52,7 @@ public class MetabolicNetwork {
     public GeneProduct getGeneProduct(String id) throws GeneProductDoesNotExitsException {
         return metabolicNetworkElements.getGeneProduct(id);
     }
+
     public List<GeneProduct> getGeneProductsAsList() {
 		return metabolicNetworkElements.getGeneProductsAsList();
 	}
@@ -109,32 +113,16 @@ public class MetabolicNetwork {
         return petriNetElements.getTransitionsIDs();
     }
 
-    public List<Place<Metabolite>> getSources() {
-        List<Place<Metabolite>> sourcePlaces = new ArrayList<>();
-        List<String> placesIDs = petriNetElements.getPlacesIDs();
-        for(String placeID: placesIDs) {
-            Place<Metabolite> place = petriNetElements.getPlace(placeID);
-            if (place.isSource()){
-                sourcePlaces.add(place);
+    public List<Reaction> getExchangeReactions() {
+        List<Reaction> exchangeReactions = new ArrayList<>();
+
+        for(Reaction reaction : metabolicNetworkElements.getReactionsAsList()) {
+            if (reaction.getProducts().isEmpty() || reaction.getReactants().isEmpty()) {
+                exchangeReactions.add(reaction);
             }
         }
 
-        return sourcePlaces;
-    }
-
-    public List<Place<Metabolite>> getSinks() {
-        List<Place<Metabolite>> sinkPlaces = new ArrayList<>();
-        List<String> placesIDs = petriNetElements.getPlacesIDs();
-
-        for(String placeID: placesIDs) {
-            Place<Metabolite> place = petriNetElements.getPlace(placeID);
-
-            if (place.isSink()){
-                sinkPlaces.add(place);
-            }
-        }
-
-        return sinkPlaces;
+        return exchangeReactions;
     }
 
     public List<String> getReversibleReactionsIds(){
@@ -188,10 +176,12 @@ public class MetabolicNetwork {
             addReaction(reaction);
         }
     }
+
     public void addReaction(Reaction reaction){
         metabolicNetworkElements.addReaction(reaction);
         petriNetElements.loadReactionToPetriNetwork(reaction);
     }
+
     public List<Reaction> getReactionsUnbalanced(){
         return metabolicNetworkElements.getReactionsUnbalanced();
     }
@@ -203,13 +193,9 @@ public class MetabolicNetwork {
     public List<Metabolite> getMetabolitesAsList() {
         return metabolicNetworkElements.getMetabolitesAsList();
     }
+
     public Map<Reaction, Map<String, String>> reactionsUnbalancedReason(List<Reaction> reactionsUnbalanced){
         return metabolicNetworkElements.reactionsUnbalancedReason(reactionsUnbalanced);
     }
 
-	
-
-	
-
-	
 }

--- a/src/main/java/metapenta/services/MetabolicNetworkService.java
+++ b/src/main/java/metapenta/services/MetabolicNetworkService.java
@@ -34,7 +34,7 @@ public class MetabolicNetworkService implements IMetabolicNetworkService {
     }
 
     public NetworkBoundaryDTO findNetworkBoundary() {
-        NetworkBoundaryService networkBoundaryService = new NetworkBoundaryService(metabolicNetwork.getSinks(), metabolicNetwork.getSources());
+        NetworkBoundaryService networkBoundaryService = new NetworkBoundaryService(metabolicNetwork.getExchangeReactions());
 
         return networkBoundaryService.getNetworkBoundary();
     }

--- a/src/main/java/metapenta/services/NetworkBoundaryService.java
+++ b/src/main/java/metapenta/services/NetworkBoundaryService.java
@@ -1,43 +1,23 @@
 package metapenta.services;
 
-import metapenta.model.metabolic.network.Metabolite;
 import metapenta.model.dto.NetworkBoundaryDTO;
-import metapenta.model.petrinet.Place;
+import metapenta.model.metabolic.network.Reaction;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class NetworkBoundaryService {
-    private List<Place<Metabolite>> sinks;
+    private final List<Reaction> exchangeReactions;
 
-    private List<Place<Metabolite>> sources;
 
-    public NetworkBoundaryService(List<Place<Metabolite>> sinks, List<Place<Metabolite>> sources){
-        this.sinks = sinks;
-        this.sources = sources;
+    public NetworkBoundaryService(List<Reaction> exchangeReactions){
+        this.exchangeReactions = exchangeReactions;
     }
 
     public NetworkBoundaryDTO getNetworkBoundary() {
-        return new NetworkBoundaryDTO(getMetabolitesSinks(), getMetabolitesSources());
+        return new NetworkBoundaryDTO(getExchangeReactions());
     }
 
-    private List<Metabolite> getMetabolitesSinks(){
-        List<Metabolite> sinksMetabolites = new ArrayList<>();
-
-        for(Place<Metabolite> place: sinks) {
-            sinksMetabolites.add(place.getObject());
-        }
-
-        return sinksMetabolites;
-    }
-
-    private List<Metabolite> getMetabolitesSources(){
-        List<Metabolite> sourcesMetabolites = new ArrayList<>();
-
-        for(Place<Metabolite> place: sources) {
-            sourcesMetabolites.add(place.getObject());
-        }
-
-        return sourcesMetabolites;
+    private List<Reaction> getExchangeReactions() {
+        return exchangeReactions;
     }
 }

--- a/src/main/java/metapenta/tools/io/writers/NetworkBoundaryWriter.java
+++ b/src/main/java/metapenta/tools/io/writers/NetworkBoundaryWriter.java
@@ -1,7 +1,7 @@
 package metapenta.tools.io.writers;
 
-import metapenta.model.metabolic.network.Metabolite;
 import metapenta.model.dto.NetworkBoundaryDTO;
+import metapenta.model.metabolic.network.Reaction;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -11,11 +11,8 @@ import java.nio.file.Paths;
 
 public class NetworkBoundaryWriter implements Writer {
 
-    private static final String SINKS_JSON_KEY = "Sinks";
-
-    private static final String SOURCES_JSON_KEY = "Sources";
+    private static final String EXCHANGE_REACTION = "ExchangeReactions";
     private NetworkBoundaryDTO networkBoundaryDTO;
-
     private String outputFile;
 
     public NetworkBoundaryWriter(NetworkBoundaryDTO networkBoundaryDTO, String outputFile){
@@ -25,29 +22,20 @@ public class NetworkBoundaryWriter implements Writer {
 
     private JSONObject getJsonBoundaryObject() {
         JSONObject networkBoundary = new JSONObject();
-        networkBoundary.put(SINKS_JSON_KEY, getSinksJsonArray());
-        networkBoundary.put(SOURCES_JSON_KEY, getSourcesJsonArray());
+        networkBoundary.put(EXCHANGE_REACTION, getExchangeReactions());
 
         return networkBoundary;
     }
 
-    private JSONArray getSinksJsonArray() {
-        JSONArray metabolites = new JSONArray();
-        for(Metabolite metabolite: networkBoundaryDTO.getSinks()){
-            metabolites.add(metabolite);
+    private JSONArray getExchangeReactions() {
+        JSONArray exchangeReactions = new JSONArray();
+        for(Reaction reaction: networkBoundaryDTO.getExchangeReactions()){
+            exchangeReactions.add(reaction);
         }
 
-        return metabolites;
+        return exchangeReactions;
     }
 
-    private JSONArray getSourcesJsonArray() {
-        JSONArray metabolites = new JSONArray();
-        for(Metabolite metabolite: networkBoundaryDTO.getSources()){
-            metabolites.add(metabolite);
-        }
-
-        return metabolites;
-    }
 
     public void write() throws IOException {
         JSONObject jsonObject = getJsonBoundaryObject();


### PR DESCRIPTION
## Context
Currently, the boundary finder returns all those metabolites with indegree or outdegree 0, these are gaps (see #16). According to Crazy Maranas' [book](https://onlinelibrary.wiley.com/doi/book/10.1002/9781119188902), the boundary of a metabolic network refers to all the exchange reactions.

## Describe your changes
In this PR I removed the `getSinks()` and `getSources()` used to erroneously find the boundary, and replaced them with `getExchangeReactions()` to properly get the network boundary. I also made some small improvements in related code.

## Test
I used [e coli core model](http://bigg.ucsd.edu/models/e_coli_core) to test. You can see the output [here](https://gist.github.com/JhersonMedina/b5596c44f3345ecd291c68121dbdece0), all shown reactions are exchange reactions.


